### PR TITLE
Threecolumns jt

### DIFF
--- a/listener-app/app.py
+++ b/listener-app/app.py
@@ -34,7 +34,8 @@ def index():
     maxy = form.data['maxy']
     nspaxel = sum(1 for _ in open('static/pixcols.csv'))
     nside = math.isqrt(nspaxel)
-    metadata = {'nside': nside}
+    metadata = {'nside': nside,
+                'ppix': 400//nside}
 
     ## On 'Generate Audio Files':
     ##     Check if new file selected, or previous filename has been saved

--- a/listener-app/render_soundgrid.py
+++ b/listener-app/render_soundgrid.py
@@ -58,7 +58,7 @@ def dsamp_ifu(a, dsamp):
     sh = shape[0],host.shape[0]//shape[0],shape[1],host.shape[1]//shape[1], host.shape[-1]
     return host.reshape(sh).mean(-2).mean(1).T
 
-def make_whitelight(data, pc=99., contrast=vcontrast, outfile="static/whitelight.png"):
+def make_whitelight(data, pc=99., contrast=vcontrast, outfile="static/images/whitelight.png"):
     wlight = data.sum(axis=0)
     # clip to percentile limit and apply contrast
     wlight = np.clip(wlight, 0, np.percentile(wlight, pc))**contrast
@@ -75,7 +75,7 @@ def make_whitelight(data, pc=99., contrast=vcontrast, outfile="static/whitelight
         else:
             hostarr[margin:wdims[0]+margin,:] = wlight
         wlight = hostarr
-    plt.imsave(outfile, wlight[::-1,::-1].T, cmap='inferno')
+    plt.imsave(outfile, wlight[::-1,::-1].T, cmap='viridis')
         
 def make_grid(fname, minwl=None, maxwl=None, minx=0, maxx=24, miny=0, maxy=24):
     '''Reads datacube. Prepares and writes data for spectra and whitelight
@@ -100,10 +100,7 @@ def make_grid(fname, minwl=None, maxwl=None, minx=0, maxx=24, miny=0, maxy=24):
         lidx = np.argmin(wlens)
         ridx = np.argmax(wlens)
         
-<<<<<<< HEAD
         ## Reduce wavelength range if valid options selected
-=======
->>>>>>> 415c4ec (produce prototype whitelight image, and revisiting integrated spectrum (in progress))
         if minwl is not None:
             if minwl > np.min(wlens) and minwl < np.max(wlens):
                 lidx = np.where(wlens>=minwl)[0][0]

--- a/listener-app/static/css/style.css
+++ b/listener-app/static/css/style.css
@@ -39,7 +39,7 @@ body.dark-mode .labels {
 }
 
 .wrapper {
-  font-family: 'Quicksand',sans-serif';
+  font-family: "Quicksand",sans-serif;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -140,4 +140,12 @@ input[type="submit"] {
   overflow: hidden;
 }
 
-
+img {
+    max-width: 100%;
+    max-height: 100%;
+}
+.card-img-top {
+    height: 400px;
+    width: 400px;
+    image-rendering: pixelated;
+}

--- a/listener-app/static/js/main.js
+++ b/listener-app/static/js/main.js
@@ -12,7 +12,7 @@ let intspecChart;
 var canvas = document.getElementById('mainCanvas');
 var ctx = canvas.getContext('2d');
 
-var panelsize = 16;
+var panelsize = ppix;
 var npanel =  nside;
 var fadetime = 0.03;
 var prefadetime = 0.03;

--- a/listener-app/templates/index.html
+++ b/listener-app/templates/index.html
@@ -6,7 +6,8 @@
     <title>Grid of Audio Files</title>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script type="text/javascript">
-      var nside = parseInt({{ metadata.nside }})
+      var nside = parseInt({{ metadata.nside }});
+      var ppix = parseInt({{ metadata.ppix }});
     </script>
     <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"></script>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
@@ -87,11 +88,11 @@
             <div style="width: 100%; margin: 0 auto;">
             <h2>Viewfinder</h2>
             
-            <img id="fullDatacube" src="../static/images/dummy.png"
+            <img id="fullDatacube" src="../static/images/whitelight.png"
                 class="card-img-top" alt="2D image of full datacube"
-                style="position:relative">
+                style="position:relative;">
             <canvas id="imageCanvas" 
-                style="position:absolute; left: 0px; top: 0px">
+		    style="position:absolute; left: 0px; top: 0px">
             </canvas>
 
       <!--<div>


### PR DESCRIPTION
Some updates & fixes from my side:

- Hack for loading manga cubes (still to properly understand LOGCUBE wavelength reading, but will load)
- Produce whitelight image, padded to always be square (robust to different IFU field dimensions)
- formatting to ensure size of viewfinder and listener windows
- fix for integrated spectrum

Still need to work out how to convert between viefinder canvas area and the effective indexing needed for cube (while also accounting for any padding to square shape